### PR TITLE
added OEM02_T19n_200311 definition for Gaomon M10K 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repo currently houses a command-line only utility that creates a user-space
 - Huion H1161
 - Huion KD100 mini Keydial
 - Gaomon M10K Pro
+- Gaomon M10K 2018
 
 ### There is an untested generic XP-Pen tablet driver that should work for the majority of devices that aren't officially supported.
 

--- a/src/huion_handler.cpp
+++ b/src/huion_handler.cpp
@@ -40,6 +40,7 @@ huion_handler::huion_handler() {
 
     // GAOMON Tablets
     addHandler(new huion_tablet(0x0311));
+    addHandler(new huion_tablet(0x0119));
 }
 
 int huion_handler::getVendorId() {

--- a/src/huion_tablet.cpp
+++ b/src/huion_tablet.cpp
@@ -101,8 +101,11 @@ std::string huion_tablet::getDeviceNameFromFirmware(std::wstring firmwareName) {
     }
 
     // GAOMON tablets
-    else if (firmwareName == L"OEM02_T19n_200311" || firmwareName == L"OEM02_T17b_190119") {
+    else if (firmwareName == L"OEM02_T19n_200311") {
         return "Gaomon M10K Pro";
+    }
+    else if (firmwareName == L"OEM02_T17b_190119"){
+        return "Gaomon M10K 2018";
     }
 
     return "Unknown device";
@@ -123,8 +126,11 @@ int huion_tablet::getAliasedDeviceIdFromFirmware(std::wstring firmwareName) {
     }
 
     // GAOMON tablets
-    else if (firmwareName == L"OEM02_T19n_200311" || firmwareName == L"OEM02_T17b_190119") {
+    else if (firmwareName == L"OEM02_T19n_200311") {
         return 0x0311;
+    }
+    else if (firmwareName == L"OEM02_T17b_190119"){
+        return 0x0119;
     }
 
     return 0x0000;

--- a/src/huion_tablet.cpp
+++ b/src/huion_tablet.cpp
@@ -101,7 +101,7 @@ std::string huion_tablet::getDeviceNameFromFirmware(std::wstring firmwareName) {
     }
 
     // GAOMON tablets
-    else if (firmwareName == L"OEM02_T19n_200311") {
+    else if (firmwareName == L"OEM02_T19n_200311" || firmwareName == L"OEM02_T17b_190119") {
         return "Gaomon M10K Pro";
     }
 
@@ -123,7 +123,7 @@ int huion_tablet::getAliasedDeviceIdFromFirmware(std::wstring firmwareName) {
     }
 
     // GAOMON tablets
-    else if (firmwareName == L"OEM02_T19n_200311") {
+    else if (firmwareName == L"OEM02_T19n_200311" || firmwareName == L"OEM02_T17b_190119") {
         return 0x0311;
     }
 


### PR DESCRIPTION
Just a little change so that other m10k can work. They are basically identical (other than the pen tilt and whatnot) but I figured I should still keep them with separate IDs