### PR TITLE
Make CMakeList obey UDEV_RULES_PATH env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,15 @@ target_link_libraries(userspace_tablet_driver_daemon stdc++fs ${LIBUSB_1_LIBRARI
 target_include_directories(userspace_tablet_driver_daemon PRIVATE ${LIBUSB_1_INCLUDE_DIRS})
 target_compile_definitions(userspace_tablet_driver_daemon PRIVATE ${LIBUSB_1_DEFINITIONS})
 
+if(NOT DEFINED UDEV_RULES_PATH)
+  set(UDEV_RULES_PATH "etc/udev/")
+endif(NOT DEFINED UDEV_RULES_PATH)
+
 if(DEFINED ENV{BUILD_PKG})
     install(TARGETS userspace_tablet_driver_daemon DESTINATION bin)
 else()
     install(TARGETS userspace_tablet_driver_daemon DESTINATION usr/bin)
-    install(DIRECTORY config/etc/ DESTINATION etc)
+    install(DIRECTORY config/etc/udev/rules.d DESTINATION ${UDEV_RULES_PATH})
     install(DIRECTORY config/usr/ DESTINATION usr)
 endif()
 


### PR DESCRIPTION
This is a quick patch to let cmake respect the UDEV_RULES_PATH environment variable. On some systems, e.g. my gentoo box, would like the udev rules to be installed into `/lib/udev` instead of `/etc/udev/` so I made this a patch to open up an interface to package maintainers.