### PR TITLE
Replace Ctrl+= with Ctrl++ for zoom 

### DIFF
--- a/src/ac19.cpp
+++ b/src/ac19.cpp
@@ -63,7 +63,7 @@ void ac19::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_9, EV_KEY, {KEY_L});
 
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
     }
     jsonConfig = config;
 

--- a/src/artist_12_pro.cpp
+++ b/src/artist_12_pro.cpp
@@ -66,7 +66,7 @@ void artist_12_pro::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_7, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTALT, KEY_N});
 
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
     }
     jsonConfig = config;
 

--- a/src/artist_13_3_pro.cpp
+++ b/src/artist_13_3_pro.cpp
@@ -62,7 +62,7 @@ void artist_13_3_pro::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_7, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTALT, KEY_N});
 
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
     }
     jsonConfig = config;
 

--- a/src/artist_15_6_pro.cpp
+++ b/src/artist_15_6_pro.cpp
@@ -73,7 +73,7 @@ void artist_15_6_pro::setConfig(nlohmann::json config) {
 
         // Mapping the dials
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
         addToDialMap(REL_HWHEEL, -1, EV_KEY, {KEY_LEFTBRACE});
         addToDialMap(REL_HWHEEL, 1, EV_KEY, {KEY_RIGHTBRACE});
     }

--- a/src/artist_22r_pro.cpp
+++ b/src/artist_22r_pro.cpp
@@ -81,7 +81,7 @@ void artist_22r_pro::setConfig(nlohmann::json config) {
 
         // Mapping the dials
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
         addToDialMap(REL_HWHEEL, -1, EV_KEY, {KEY_LEFTBRACE});
         addToDialMap(REL_HWHEEL, 1, EV_KEY, {KEY_RIGHTBRACE});
     }

--- a/src/artist_24_pro.cpp
+++ b/src/artist_24_pro.cpp
@@ -83,7 +83,7 @@ void artist_24_pro::setConfig(nlohmann::json config) {
 
         // Mapping the dials
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
         addToDialMap(REL_HWHEEL, -1, EV_KEY, {KEY_LEFTBRACE});
         addToDialMap(REL_HWHEEL, 1, EV_KEY, {KEY_RIGHTBRACE});
     }

--- a/src/artist_pro_16.cpp
+++ b/src/artist_pro_16.cpp
@@ -65,7 +65,7 @@ void artist_pro_16::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_7, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTALT, KEY_N});
 
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
     }
     jsonConfig = config;
 

--- a/src/deco_03.cpp
+++ b/src/deco_03.cpp
@@ -57,7 +57,7 @@ void deco_03::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_4, EV_KEY, {KEY_V});
         addToButtonMap(BTN_5, EV_KEY, {KEY_LEFTCTRL, KEY_S});
 
-        addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
         addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
     }
     jsonConfig = config;

--- a/src/deco_pro.cpp
+++ b/src/deco_pro.cpp
@@ -57,9 +57,9 @@ void deco_pro::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_7, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTALT, KEY_N});
 
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
         addToDialMap(REL_HWHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_HWHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_HWHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
     }
     jsonConfig = config;
 

--- a/src/generic_xp_pen_device.cpp
+++ b/src/generic_xp_pen_device.cpp
@@ -74,7 +74,7 @@ void generic_xp_pen_device::setConfig(nlohmann::json config) {
 
         // Mapping the dials
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
         addToDialMap(REL_HWHEEL, -1, EV_KEY, {KEY_LEFTBRACE});
         addToDialMap(REL_HWHEEL, 1, EV_KEY, {KEY_RIGHTBRACE});
     }

--- a/src/huion_tablet.cpp
+++ b/src/huion_tablet.cpp
@@ -62,7 +62,7 @@ void huion_tablet::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_3, EV_KEY, {KEY_E});
         addToButtonMap(BTN_4, EV_KEY, {KEY_RIGHTBRACE});
         addToButtonMap(BTN_5, EV_KEY, {KEY_LEFTBRACE});
-        addToButtonMap(BTN_6, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToButtonMap(BTN_6, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
         addToButtonMap(BTN_7, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
         addToButtonMap(BTN_8, EV_KEY, {KEY_SPACE});
         addToButtonMap(BTN_9, EV_KEY, {KEY_F6});
@@ -71,7 +71,7 @@ void huion_tablet::setConfig(nlohmann::json config) {
 
         // Mapping the touch-strips
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
     }
     jsonConfig = config;
 

--- a/src/innovator_16.cpp
+++ b/src/innovator_16.cpp
@@ -60,7 +60,7 @@ void innovator_16::setConfig(nlohmann::json config) {
         addToButtonMap(BTN_7, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTALT, KEY_N});
 
         addToDialMap(REL_WHEEL, -1, EV_KEY, {KEY_LEFTCTRL, KEY_MINUS});
-        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_EQUAL});
+        addToDialMap(REL_WHEEL, 1, EV_KEY, {KEY_LEFTCTRL, KEY_LEFTSHIFT, KEY_EQUAL});
     }
     jsonConfig = config;
 


### PR DESCRIPTION
Works better in most art programs and isn't an "ambiguous" input as described by Krita.