### PR TITLE
Add initial Eraser support to xp_pen_unified_device.cpp

### DIFF
--- a/src/transfer_handler.h
+++ b/src/transfer_handler.h
@@ -60,12 +60,19 @@ protected:
 
     virtual void submitMapping(const nlohmann::json& config);
 
+    virtual bool hasCustomButtonMap(int button);
+
     virtual void handleUnknownUsbMessage(libusb_device_handle *handle, unsigned char *data, size_t dataLen);
+
+    virtual void handleEraserEnteredProximity(libusb_device_handle* handle);
+    virtual void handleEraserLeftProximity(libusb_device_handle* handle);
 
     virtual void handlePenEnteredProximity(libusb_device_handle* handle);
     virtual void handlePenLeftProximity(libusb_device_handle* handle);
 
     virtual void handlePenTouchingDigitizer(libusb_device_handle* handle, int pressure);
+
+    virtual void handleStylusMappedEvent(libusb_device_handle *handle, int event, int value);
 
     virtual void handleStylusButtonsPressed(libusb_device_handle* handle, int stylusButton);
     virtual void handleStylusButtonUnpressed(libusb_device_handle* handle);
@@ -96,6 +103,7 @@ protected:
     nlohmann::json jsonConfig;
 
     bool penInProximity;
+    bool eraserInProximity;
     bool penWasDown;
     int stylusButtonPressed;
 

--- a/src/xp_pen_unified_device.cpp
+++ b/src/xp_pen_unified_device.cpp
@@ -95,7 +95,7 @@ bool xp_pen_unified_device::attachDevice(libusb_device_handle *handle, int inter
 
     return true;
 }
-
+#include <iomanip>
 void xp_pen_unified_device::handleDigitizerEvent(libusb_device_handle *handle, unsigned char *data, size_t dataLen, int offsetPressure) {
     if (data[1] <= 0xc0) {
         // Extract the X and Y position
@@ -112,11 +112,23 @@ void xp_pen_unified_device::handleDigitizerEvent(libusb_device_handle *handle, u
         int pressure = (data[7] << 8) + data[6];
         pressure += offsetPressure;
 
+        const bool isInProximity = stylusTipAndButton.test(5) && !stylusTipAndButton.test(4);
+        const bool isEraserBit = stylusTipAndButton.test(3);
+
+        const bool hasEraserEnteredProximity = isInProximity && isEraserBit;
+        const bool hasPenEnteredProximity = isInProximity && !isEraserBit;
+        const bool hasPenExitedProximity = stylusTipAndButton.test(6) && !eraserInProximity;
+        const bool hasEraserExitedProximity = stylusTipAndButton.test(6);
+
         // Handle pen coming into/out of proximity
-        if (stylusTipAndButton.test(5)) {
+        if (hasEraserEnteredProximity) {
+            handleEraserEnteredProximity(handle);
+        } else if (hasPenEnteredProximity) {
             handlePenEnteredProximity(handle);
-        } else if (stylusTipAndButton.test(6)) {
+        } else if (hasPenExitedProximity) {
             handlePenLeftProximity(handle);
+        } else if (hasEraserExitedProximity) {
+            handleEraserLeftProximity(handle);
         }
 
         // Handle actual stylus to digitizer contact

--- a/src/xp_pen_unified_device.cpp
+++ b/src/xp_pen_unified_device.cpp
@@ -95,7 +95,7 @@ bool xp_pen_unified_device::attachDevice(libusb_device_handle *handle, int inter
 
     return true;
 }
-#include <iomanip>
+
 void xp_pen_unified_device::handleDigitizerEvent(libusb_device_handle *handle, unsigned char *data, size_t dataLen, int offsetPressure) {
     if (data[1] <= 0xc0) {
         // Extract the X and Y position


### PR DESCRIPTION
I took inspiration from #62 and tried to rework it to only press a custom key when entering proximity. I also added the ability to add keybinds to the pen tip entering proximity so you can switch back and forth between tools when alternating ends of the pen.

[kurikaesu/userspace-tablet-driver-gui#14](https://github.com/kurikaesu/userspace-tablet-driver-gui/pull/14) adds support for binding keybinds to eraser proximity entry and could be easily extended to add support for pen proximity as well.

This should close #60.