### PR TITLE
fixing minor typeof() usage bug that affects non 64bits archs

### DIFF
--- a/src/artist_12_pro.cpp
+++ b/src/artist_12_pro.cpp
@@ -93,7 +93,7 @@ void artist_12_pro::handleFrameEvent(libusb_device_handle *handle, unsigned char
         // Only 8 buttons on this device
         long position = ffsl(data[2]);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the dial
         short dialValue = 0;

--- a/src/artist_13_3_pro.cpp
+++ b/src/artist_13_3_pro.cpp
@@ -89,7 +89,7 @@ void artist_13_3_pro::handleFrameEvent(libusb_device_handle *handle, unsigned ch
         // Only 8 buttons on this device
         long position = ffsl(data[2]);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the dial
         short dialValue = 0;

--- a/src/artist_15_6_pro.cpp
+++ b/src/artist_15_6_pro.cpp
@@ -105,7 +105,7 @@ void artist_15_6_pro::handleFrameEvent(libusb_device_handle *handle, unsigned ch
         // Grab the first bit set in the button long which tells us the button number
         long position = ffsl(button);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the left dial
         short leftDialValue = 0;

--- a/src/artist_22r_pro.cpp
+++ b/src/artist_22r_pro.cpp
@@ -113,7 +113,7 @@ void artist_22r_pro::handleFrameEvent(libusb_device_handle *handle, unsigned cha
         // Grab the first bit set in the button long which tells us the button number
         long position = ffsl(button);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the left dial
         short leftDialValue = 0;

--- a/src/artist_24_pro.cpp
+++ b/src/artist_24_pro.cpp
@@ -115,7 +115,7 @@ void artist_24_pro::handleFrameEvent(libusb_device_handle *handle, unsigned char
         // Grab the first bit set in the button long which tells us the button number
         long position = ffsl(button);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the left dial
         short leftDialValue = 0;

--- a/src/artist_pro_16.cpp
+++ b/src/artist_pro_16.cpp
@@ -92,7 +92,7 @@ void artist_pro_16::handleFrameEvent(libusb_device_handle *handle, unsigned char
         // Only 8 buttons on this device
         long position = ffsl(data[2]);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the dial
         short dialValue = 0;

--- a/src/deco.cpp
+++ b/src/deco.cpp
@@ -77,7 +77,7 @@ void deco::handleUnifiedFrameEvent(libusb_device_handle *handle, unsigned char *
         // Only 8 buttons on this device
         long position = ffsl(data[2]);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the dial
         short dialValue = 0;

--- a/src/deco_03.cpp
+++ b/src/deco_03.cpp
@@ -101,7 +101,7 @@ void deco_03::handleFrameEvent(libusb_device_handle *handle, unsigned char *data
 
 void deco_03::handleNonUnifiedDialEvent(libusb_device_handle *handle, unsigned char *data, size_t dataLen) {
     if (data[1] == 0x01) {
-        std::bitset<sizeof(data)> dialBits(data[2]);
+        std::bitset<8> dialBits(data[2]);
 
         // Take the dial
         short dialValue = 0;

--- a/src/deco_pro.cpp
+++ b/src/deco_pro.cpp
@@ -97,7 +97,7 @@ void deco_pro::handleUnifiedFrameEvent(libusb_device_handle *handle, unsigned ch
         // Only 8 buttons on this device
         long position = ffsl(data[2]);
 
-        std::bitset<sizeof(data)> touchAndDialBits(data[7]);
+        std::bitset<8> touchAndDialBits(data[7]);
 
         // Take the dial
         short dialValue = 0;

--- a/src/generic_xp_pen_device.cpp
+++ b/src/generic_xp_pen_device.cpp
@@ -104,7 +104,7 @@ void generic_xp_pen_device::handleFrameEvent(libusb_device_handle *handle, unsig
         // Grab the first bit set in the button long which tells us the button number
         long position = ffsl(button);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the left dial
         short leftDialValue = 0;

--- a/src/huion_tablet.cpp
+++ b/src/huion_tablet.cpp
@@ -363,7 +363,7 @@ void huion_tablet::handleDigitizerEventV1(libusb_device_handle *handle, unsigned
     int penX = (data[3] << 8) + data[2];
     int penY = (data[5] << 8) + data[4];
 
-    std::bitset<sizeof(data)> stylusTipAndButton(data[1]);
+    std::bitset<8> stylusTipAndButton(data[1]);
 
     // Check to see if the pen is touching
     int pressure = (data[7] << 8) + data[6];
@@ -395,7 +395,7 @@ void huion_tablet::handleDigitizerEventV2(libusb_device_handle *handle, unsigned
     int penY = (data[5] << 8) + data[4];
 
     // Check to see if the pen is touching
-    std::bitset<sizeof(data)> stylusTipAndButton(data[1]);
+    std::bitset<8> stylusTipAndButton(data[1]);
     int pressure = (data[7] << 8) + data[6];
 
     if (stylusTipAndButton.test(0)) {
@@ -430,7 +430,7 @@ void huion_tablet::handleDigitizerEventV3(libusb_device_handle *handle, unsigned
         int penY = (data[5] << 8) + data[4];
 
         // Check to see if the pen is touching
-        std::bitset<sizeof(data)> stylusTipAndButton(data[1]);
+        std::bitset<8> stylusTipAndButton(data[1]);
         int pressure = (data[7] << 8) + data[6];
 
         if (stylusTipAndButton.test(0)) {

--- a/src/innovator_16.cpp
+++ b/src/innovator_16.cpp
@@ -87,7 +87,7 @@ void innovator_16::handleFrameEvent(libusb_device_handle *handle, unsigned char 
         // Only 8 buttons on this device
         long position = ffsl(data[2]);
 
-        std::bitset<sizeof(data)> dialBits(data[7]);
+        std::bitset<8> dialBits(data[7]);
 
         // Take the dial
         short dialValue = 0;

--- a/src/xp_pen_unified_device.cpp
+++ b/src/xp_pen_unified_device.cpp
@@ -108,7 +108,7 @@ void xp_pen_unified_device::handleDigitizerEvent(libusb_device_handle *handle, u
         }
 
         // Check to see if the pen is touching
-        std::bitset<sizeof(data)> stylusTipAndButton(data[1]);
+        std::bitset<8> stylusTipAndButton(data[1]);
         int pressure = (data[7] << 8) + data[6];
         pressure += offsetPressure;
 


### PR DESCRIPTION
For some devices, in the ::handleNonUnifiedDialEvent() we declare an std::bitset<sizeof(data)> holding a bitset representation of an unsigned char with data being of type (unsigned char *).
This is incorrect as sizeof(data) returns the size of a pointer in bytes, when we are expecting to have the number of bits in an unsigned char (8 bits).
It happens to work on x64 archs because a pointer happens to be 8 bytes, in 32bit architectures this would create an std::bitset<4> which will cause an std::out_of_range exception on runtime when testing for the fifth bit for example.