### PR TITLE
Fix Deco 03 not working on wireless mode

### DIFF
--- a/src/deco_03.cpp
+++ b/src/deco_03.cpp
@@ -35,6 +35,10 @@ std::string deco_03::getProductName(int productId) {
     return "Unknown XP-Pen Device";
 }
 
+std::string deco_03::getInitKey() {
+    return {0x02, static_cast<char>(0xb0), 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+}
+
 void deco_03::setConfig(nlohmann::json config) {
     if (!config.contains("mapping") || config["mapping"] == nullptr) {
         config["mapping"] = nlohmann::json({});

--- a/src/deco_03.h
+++ b/src/deco_03.h
@@ -32,6 +32,8 @@ public:
 private:
     void handleFrameEvent(libusb_device_handle* handle, unsigned char* data, size_t dataLen);
     void handleNonUnifiedDialEvent(libusb_device_handle* handle, unsigned char* data, size_t dataLen);
+    
+    virtual std::string getInitKey() override;
 };
 
 


### PR DESCRIPTION
- The XP-Pen Deco 03 was not working when used wirelessly
- After investigating with the vendor driver, the problem appeared to be caused by the init key.
- The one sent by the driver was different from the one used in xp_pen_unified_device.cpp .
- The one used in xp_pen_unified_device.cpp worked when the Deco 03 was plugged with a USB cable, but not with the wireless plug, the driver one works for both.
- Fixed the problem by overriding getInitKey in deco_03