### PR TITLE
Add "-fsigned-char" to compiler flags, fixes bugs when compiling for ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(userspace_tablet_driver_daemon src/main.cpp src/usb_devices.cpp s
 target_link_libraries(userspace_tablet_driver_daemon stdc++fs ${LIBUSB_1_LIBRARIES})
 target_include_directories(userspace_tablet_driver_daemon PRIVATE ${LIBUSB_1_INCLUDE_DIRS})
 target_compile_definitions(userspace_tablet_driver_daemon PRIVATE ${LIBUSB_1_DEFINITIONS})
+target_compile_options(userspace_tablet_driver_daemon PRIVATE -fsigned-char)
 
 if(NOT DEFINED UDEV_RULES_PATH)
   set(UDEV_RULES_PATH "etc/udev/")


### PR DESCRIPTION
`char` is unsigned by default on ARM, unlike x86, which causes a few problems such as tilt values being wildly incorrect.
technically, the "correct" way to fix this is to be explicit and replace all `char` with `signed char`, but this compiler flag works too.