### PR TITLE
Fixed Artist Pro 16TP functionality

### DIFF
--- a/src/artist_pro_16tp.h
+++ b/src/artist_pro_16tp.h
@@ -28,6 +28,7 @@ public:
 
     // Override only the methods that need custom behavior
     bool handleTransferData(libusb_device_handle* handle, unsigned char* data, size_t dataLen, int productId) override;
+    bool attachDevice(libusb_device_handle *handle, int interfaceId, int productId) override;
 };
 
 


### PR DESCRIPTION
A recent change set an incorrect device ID and caused the probed maxWidth property to be incorrect. This change corrects the device ID value and hardcodes the correct digitizer dimensions for the XP-Pen Artist Pro 16TP.